### PR TITLE
Update the tox environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          python -m pip install -e .
+          sh build.sh
           pip install tox tox-gh-actions
       - name: Run tests using tox
         run: tox -e ${{ matrix.env }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,13 @@ jobs:
           - python: "3.11"
             env: py311-django41
 
+          - python: "3.9"
+            env: py39-django42
+          - python: "3.10"
+            env: py310-django42
+          - python: "3.11"
+            env: py311-django42
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/django_mermaid/static/mermaid *

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# last version of `build` supporting Python 3.6
+pip install build==0.9.0
+
+# build the wheel and install it
+WHEEL_NAME=$(python -m build | grep -Po "django_mermaid-.*\.whl" | tail -n 1)
+pip install dist/$WHEEL_NAME

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -1,4 +1,3 @@
-from os.path import dirname
 from os.path import exists
 from os.path import join
 
@@ -7,6 +6,15 @@ from django.template import Context
 from django.template import Template
 from django.test import override_settings
 from django_mermaid.templatetags import DEFAULT_THEME
+
+try:
+    import site
+
+    site_packages = site.getsitepackages()[0]
+except (ImportError, IndexError):
+    import sysconfig
+
+    site_packages = sysconfig.get_paths()["purelib"]
 
 
 def test_tag_use_in_template(version):
@@ -63,6 +71,7 @@ def test_tag_use_custom_theme_variables_with_base_theme(version):
     )
 
 
-def test_tag_use_custom_version(version):
-    static_dir = join(dirname(__file__), "..", "src", "django_mermaid", "static")
-    assert exists(join(static_dir, "mermaid", version, "mermaid.js"))
+def test_tag_use_custom_version():
+    static_dir = join(site_packages, "django_mermaid", "static")
+    assert exists(join(static_dir, "mermaid", "8.6.3", "mermaid.js"))
+    assert exists(join(static_dir, "mermaid", "9.4.3", "mermaid.js"))

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     django21: django<2.2
     django11: django<2.0
     -r{toxinidir}/tests/requirements.txt
+allowlist_externals = sh
 commands =
-    pip install -e .
+    sh build.sh
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     py{36,38,39}-django21
     py{36,38,310}-django32
     py{38,39,310}-django40
-    py{39,310,311}-django{41,main}
+    py{39,310,311}-django{41,42}
+    py{310,311}-djangomain
 
 [testenv]
 deps =


### PR DESCRIPTION
### Motivation:

Python 3.9 is no longer supported on Django main (5.0).
From [Python Compatibility](https://docs.djangoproject.com/en/dev/releases/5.0/#python-compatibility) of the 5.0 (pre) release notes:
> The Django 4.2.x series is the last to support Python 3.8 and 3.9.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you updated the documentation related to the changes you have made?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Co-authored-by: ArtyomVancyan <artyom.vancyan2000@gmail.com>