### PR TITLE
Remove usage of distutils

### DIFF
--- a/src/django_mermaid/apps.py
+++ b/src/django_mermaid/apps.py
@@ -1,8 +1,4 @@
-from distutils import dir_util
-from os import stat
-from os.path import dirname
-from os.path import exists
-from os.path import join
+import pathlib
 from urllib.request import urlretrieve
 
 from django.apps import AppConfig
@@ -18,9 +14,11 @@ class MermaidConfig(AppConfig):
         """Download mermaid.js from CDN if not already present"""
         version = getattr(settings, "MERMAID_VERSION", DEFAULT_VERSION)
         cdn = "https://cdnjs.cloudflare.com/ajax/libs/mermaid/%s/mermaid.min.js" % version
-        static_dir = join(dirname(__file__), "static")
-        mermaid_dir = join(static_dir, "mermaid", version)
-        if not exists(join(mermaid_dir, "mermaid.js")) or \
-                stat(join(mermaid_dir, "mermaid.js")).st_size == 0:
-            dir_util.create_tree(mermaid_dir, ["mermaid.js"])
-            urlretrieve(cdn, join(mermaid_dir, "mermaid.js"))
+        current_dir = pathlib.Path(__file__).parent
+        static_dir = current_dir / "static"
+        mermaid_dir = static_dir / "mermaid" / version
+        mermaid_js = mermaid_dir / "mermaid.js"
+        if not mermaid_js.exists() or \
+               mermaid_js.stat().st_size == 0:
+            mermaid_dir.mkdir(parents=True, exist_ok=True)
+            urlretrieve(cdn, str(mermaid_js))


### PR DESCRIPTION
### Motivation:
[distutils is deprecated in Python 3.10 and scheduled to be removed in Python 3.12](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated).

It's used to create the full directory tree for storing the files, we can replace that with [pathlib.Path.mkdir](https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir).

Since we already have a `Path` object now, we can also replace calls to `os.path.join`, `os.stat` with calls on `Path`.

For the tests to pass, it would be best to merge #15.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
